### PR TITLE
Fix parentheses in type-fu integration

### DIFF
--- a/integrations/typefu/Halmak.tfl
+++ b/integrations/typefu/Halmak.tfl
@@ -55,13 +55,13 @@
     "Digit9": {
       "default": {
         "base": "9",
-        "shift": "("
+        "shift": "<"
       }
     },
     "Digit0": {
       "default": {
         "base": "0",
-        "shift": ")"
+        "shift": ">"
       }
     },
     "KeyA": {
@@ -103,13 +103,13 @@
     "KeyG": {
       "default": {
         "base": ",",
-        "shift": "<"
+        "shift": "("
       }
     },
     "KeyH": {
       "default": {
         "base": ".",
-        "shift": ">"
+        "shift": ")"
       }
     },
     "KeyI": {


### PR DESCRIPTION
The Type Fu file places the parentheses `(` and `)` on the `9` and `0` keys, but the Mac integration places them on the `,` and `.` keys and moves the angled brackets `<` and `>` to the `9` and `0` keys.

This PR makes the Type Fu file match the Mac layout. (It looks to me like the Linux integration also matches the Mac layout, but the Kinesis integration might not.)